### PR TITLE
Fix for v13

### DIFF
--- a/css/aria.css
+++ b/css/aria.css
@@ -3710,3 +3710,11 @@ strong {
 #configRollDialog .optionTitle {
   vertical-align: middle;
 }
+
+.tab[data-tab]:not(.active) {
+  display: none;
+}
+
+.tab[data-tab] {
+  display: block;
+}

--- a/css/aria.css
+++ b/css/aria.css
@@ -366,7 +366,7 @@ strong {
 /* ----------------------------------------- */
 /*  Flexbox                                  */
 /* ----------------------------------------- */
-.flexrow {
+.aria .flexrow {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -379,67 +379,67 @@ strong {
   justify-content: flex-start;
 }
 
-.flexrow > * {
+.aria .flexrow > * {
   -webkit-box-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.flexrow .flex1 {
+.aria .flexrow .flex1 {
   -webkit-box-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.flexrow .flex2 {
+.aria .flexrow .flex2 {
   -webkit-box-flex: 2;
   -ms-flex: 2;
   flex: 2;
 }
 
-.flexrow .flex3 {
+.aria .flexrow .flex3 {
   -webkit-box-flex: 3;
   -ms-flex: 3;
   flex: 3;
 }
 
-.flexrow .flex4 {
+.aria .flexrow .flex4 {
   -webkit-box-flex: 4;
   -ms-flex: 4;
   flex: 4;
 }
 
-.flexrow .flex5 {
+.aria .flexrow .flex5 {
   -webkit-box-flex: 5;
   -ms-flex: 5;
   flex: 5;
 }
 
-.flexrow .flex6 {
+.aria .flexrow .flex6 {
   -webkit-box-flex: 6;
   -ms-flex: 6;
   flex: 6;
 }
 
-.flexrow .flex7 {
+.aria .flexrow .flex7 {
   -webkit-box-flex: 7;
   -ms-flex: 7;
   flex: 7;
 }
 
-.flexrow .flex8 {
+.aria .flexrow .flex8 {
   -webkit-box-flex: 8;
   -ms-flex: 8;
   flex: 8;
 }
 
-.flexrow .flex9 {
+.aria .flexrow .flex9 {
   -webkit-box-flex: 9;
   -ms-flex: 9;
   flex: 9;
 }
 
-.flexcol {
+.aria .flexcol {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -449,31 +449,31 @@ strong {
   flex-flow: column nowrap;
 }
 
-.flexcol > * {
+.aria .flexcol > * {
   -webkit-box-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.flexcol .flex1 {
+.aria .flexcol .flex1 {
   -webkit-box-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.flexcol .flex2 {
+.aria .flexcol .flex2 {
   -webkit-box-flex: 2;
   -ms-flex: 2;
   flex: 2;
 }
 
-.flexcol .flex3 {
+.aria .flexcol .flex3 {
   -webkit-box-flex: 3;
   -ms-flex: 3;
   flex: 3;
 }
 
-.flexcol .flex4 {
+.aria .flexcol .flex4 {
   -webkit-box-flex: 4;
   -ms-flex: 4;
   flex: 4;
@@ -3709,12 +3709,4 @@ strong {
 
 #configRollDialog .optionTitle {
   vertical-align: middle;
-}
-
-.tab[data-tab]:not(.active) {
-  display: none;
-}
-
-.tab[data-tab] {
-  display: block;
 }

--- a/module/cards/player-hand.js
+++ b/module/cards/player-hand.js
@@ -1,4 +1,4 @@
-export class AriaPlayerHand extends CardsHand {
+export class AriaPlayerHand extends CardHand {
 
     static get defaultOptions() {
         return foundry.utils.mergeObject(super.defaultOptions, {


### PR DESCRIPTION
Au passage à ApplicationV2 `CardsHand` a été renommé en `CardHand`.
Correction du CSS des tabs. Le CSS pour afficher uniquement l'onglet actif était écrasé par celui de .flexcol.